### PR TITLE
chore: initialize Flutter PoC project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,36 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# Visual Studio Code
+.vscode/
+
+# Flutter/Dart/Pub related
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+.pub-cache/
+.pub/
+build/
+flutter_*.png
+generated_plugin_registrant.dart
+
+# Web related
+lib/generated_plugin_registrant.dart
+
+# Symbolic links
+symlinks

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# justlive
+# Justlive
+
+Proof of concept Flutter project.
+
+## Getting Started
+
+This project was initialized with Flutter for a proof of concept.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:flutter_lints/flutter.yaml

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Justlive PoC',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: const Scaffold(
+        body: Center(child: Text('Hello, Justlive!')),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,20 @@
+name: justlive
+description: A new Flutter project.
+publish_to: 'none'
+
+version: 0.1.0
+
+environment:
+  sdk: ">=2.19.0 <4.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^2.0.0
+
+flutter:
+  uses-material-design: true

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:justlive/main.dart';
+
+void main() {
+  testWidgets('Home screen contains greeting', (WidgetTester tester) async {
+    await tester.pumpWidget(const MyApp());
+    expect(find.text('Hello, Justlive!'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- set up minimal Flutter project structure with main app and unit test
- configure lints and standard ignores

## Testing
- `flutter test` *(fails: Unable to 'pub upgrade' flutter tool)*

------
https://chatgpt.com/codex/tasks/task_e_68994a3d4030832a817bd87fd2385650